### PR TITLE
Fixing compatibility.

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -132,7 +132,7 @@ and then upgrade SSO v1.3 to SSO v1.4 as soon as possible.
         <li> The SSO v1.2.x tiles are compatible with PCF v1.8.x and later</li>
         <li> The SSO v1.3.x tiles are compatible with PCF v1.9.x and later</li>
         <li> The SSO v1.4.x tiles are compatible with PCF v1.11.x and later</li>
-        <li> The SSO v1.5.x tiles are compatible with PCF v1.12.x and v2.0.x</li>
+        <li> The SSO v1.5.x tiles are compatible with PCF v1.12.x, and v1.5.3+ are compatible with v2.0.x and v2.1.x</li>
  </ul>
  </div>
 


### PR DESCRIPTION
These version compatibility were updated elsewhere later but not in these paragraphs.

SSO 1.5.3 and later specifically will work with v2.0 and v2.1, but won't work with v2.2 and later.