### PR TITLE
Updating docs for Xenial fix for OpsMan 2.1.15+

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -38,11 +38,11 @@ The following table provides version and version-support information about [Sing
     </tr>
     <tr>
         <td>Compatible Ops Manager version(s)</td>
-        <td>v2.2.2 or later and v2.3.x</td>
+        <td>v2.1.15 or later, v2.2.2 or later and v2.3.x</td>
     </tr>
     <tr>
         <td>Compatible Pivotal Application Service (PAS) version(s)</td>
-        <td>v2.2.x and v2.3.x</td>
+        <td>v2.1.x, v2.2.x and v2.3.x</td>
     </tr>
     <tr>
         <td>IaaS support</td>
@@ -75,13 +75,13 @@ This table lists the supported versions of SSO on PCF.
   </tr>
   <tr>
     <th rowspan="1">2.1.x</th>
-    <td>1.7.0*</td>
+    <td>1.7.1 (OpsMan v2.1.15 or higher)</td>
     <td>1.6.0</td>
   </tr>
   <tr>
     <th rowspan="1">2.0.x</th>
     <td>1.6.0</td>
-    <td>1.5.3**</td>
+    <td>1.5.3*</td>
   </tr>
   <tr>
     <th rowspan="1">1.12.x</th>
@@ -95,9 +95,7 @@ This table lists the supported versions of SSO on PCF.
   </tr>
 </table>
 
-\* SSO v1.7.1 is not supported on PCF v2.1 because of an issue with Xenial stemcells.
-
-\** If you are upgrading from PCF v1.12 to v2.0, see 
+\* If you are upgrading from PCF v1.12 to v2.0, see 
 [Upgrade SSO Service Tile Between PCF 1.12 and PCF 2.0](https://community.pivotal.io/s/article/Upgrade-SSO-Service-Tile-Between-PCF-112-and-PCF-20)
 in the Pivotal Support knowledge base.
 


### PR DESCRIPTION
We removed PCF 2.1 support for SSO 1.7.1 due to a Xenial issue. The Xenial issue was fixed in OpsMan v2.1.15+, so we are adding it back into support.