### PR TITLE
Clarify PCF versions and grant types

### DIFF
--- a/integrating-sso.html.md.erb
+++ b/integrating-sso.html.md.erb
@@ -44,11 +44,9 @@ To validate the token, you must verify the following:
 
 4. The expiry time of the token, `exp`, has not passed.
 
-<!-- This should probs be in a release note -->
-
 ### <a id="using-login-hint"></a> Using Login Hints
 
-For PAS v2.3 and later, when making an authorization code grant request, a login hint can be provided so that the end user is automatically redirected to the appropriate IDP.
+For PCF v2.2 and later, when making an authorization code, password, or implicit grant request, a login hint can be provided so that the end user is automatically redirected to the appropriate IDP.
 
-A login hint can be configured using `login_hint` in a query parameter. For information
+An encoded JSON string containing `origin_key` tied to the origin key of an identity provider can be provided as a login hint using `login_hint` in a query parameter. For information
 about this field, see the [UAA documentation](http://docs.cloudfoundry.org/api/uaa/version/4.24.0/index.html#authorization-code-grant).


### PR DESCRIPTION
Fixed to PCF 2.2+, and clarified all possibly grant types as well as potential format required.