### PR TITLE
Fix Compatibility & Upgrade Docs

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -34,7 +34,7 @@ The following table provides version and version-support information about [Sing
     </tr>
     <tr>
         <td>Release date</td>
-        <td>Month XX, 2018</td>
+        <td>December XX, 2018</td>
     </tr>
     <tr>
         <td>Compatible Ops Manager version(s)</td>
@@ -80,21 +80,19 @@ This table lists the supported versions of SSO on PCF.
   </tr>
   <tr>
     <th rowspan="1">2.1.x</th>
-    <td>1.7.0*</td>
+    <td>1.7.2 (OpsMan v2.1.15 or higher)</td>
     <td>1.6.0</td>
   </tr>
 </table>
 
-\* SSO v1.7.1 and later is not supported on PCF v2.1 because of an issue with Xenial stemcells.
-
 ### <a id='upgrading-example'></a> Upgrade Path to SSO v1.8
 
-If you are using SSO v1.7.0 and PCF v2.2.0 and want to upgrade to the
-recommended version of SSO and PCF v2.3.x, do the following:
+If you are using SSO v1.7.X and PCF v2.3.X and want to upgrade to the
+recommended version of SSO and PCF v2.4.x, do the following:
 
-1. Upgrade to SSO v1.8.0 on PCF v2.2.x.
+1. Upgrade to SSO v1.8.0 on PCF v2.3.x.
 
-1. Upgrade PCF to v2.3.x.
+1. Upgrade PCF to v2.4.x.
 
     For how to upgrade PCF,
     see [Upgrading Pivotal Cloud Foundry](https://docs.pivotal.io/pivotalcf/2-3/customizing/upgrading-pcf.html).


### PR DESCRIPTION
- Xenial note was incorrect, SSO 1.7.1+ works on OpsMan 2.1.15+
- Upgrade path should be specific to upgrade steps when moving to latest PCF (2.4)