### PR TITLE
Remove OpsMan and PAS required versions here

### DIFF
--- a/installation.html.md.erb
+++ b/installation.html.md.erb
@@ -8,10 +8,9 @@ This topic explains how to install Single Sign-On (SSO) for Pivotal Cloud Foundr
 
 ## <a id='pre-reqs'></a> Prerequisites
 
-* [Ops Manager](https://network.pivotal.io/products/ops-manager) v2.1 or later
+* [Ops Manager](https://network.pivotal.io/products/ops-manager)
 
 * [Pivotal Application Service](https://network.pivotal.io/products/elastic-runtime)
-v2.1 or v2.2
 
 * SSL certificates
 


### PR DESCRIPTION
Customers can use compatibility matrix in the Overview page.

This also aligns with the page in SSO 1.7 (someone else from Docs team must have made the change there, and I like it).