### PR TITLE
Fix links for resource permissions mapping

### DIFF
--- a/configure-id-providers.html.md.erb
+++ b/configure-id-providers.html.md.erb
@@ -287,7 +287,7 @@ You can find these credentials in your Pivotal Application Service (PAS) tile in
 1. Click **Save Permissions Mapping**.
 
 <p class="note"><strong>Note</strong>: Groups with unsupported characters in Permission Mappings are not editable.</p>
-<p class="note"><strong>Note</strong>: For automation purposes with uaac, this activity may also be performed using <code>uaac group mappings</code> and <code>uaac group map</code>.</p>
+<p class="note"><strong>Note</strong>: For automation purposes with uaac, this [activity](https://docs.cloudfoundry.org/uaa/uaa-user-management.html#external-group) may also be performed using <code>uaac group mappings</code> and <code>uaac group map</code>.</p>
 
 ## <a id='delete-resource-perm'></a> Delete Resource Permissions Mapping
 

--- a/configure-id-providers.html.md.erb
+++ b/configure-id-providers.html.md.erb
@@ -287,7 +287,7 @@ You can find these credentials in your Pivotal Application Service (PAS) tile in
 1. Click **Save Permissions Mapping**.
 
 <p class="note"><strong>Note</strong>: Groups with unsupported characters in Permission Mappings are not editable.</p>
-<p class="note"><strong>Note</strong>: For automation purposes with uaac, this [activity](https://docs.cloudfoundry.org/uaa/uaa-user-management.html#external-group) may also be performed using <code>uaac group mappings</code> and <code>uaac group map</code>.</p>
+<p class="note"><strong>Note</strong>: For automation purposes with uaac, this [activity](https://docs.cloudfoundry.org/uaa/uaa-user-management.html#external-group) may also be performed using <code>uaac group mappings</code> and <code>uaac group map</code> using an [identity zone admin client](./configure-id-providers-api.html#creating).</p>
 
 ## <a id='delete-resource-perm'></a> Delete Resource Permissions Mapping
 

--- a/configure-id-providers.html.md.erb
+++ b/configure-id-providers.html.md.erb
@@ -249,7 +249,7 @@ Also, LDAP service accounts should not be subject to automated deletions, since 
 
 An administrator can include groups from an external identity provider in a Group Whitelist. The list of groups in the whitelist propagates in the ID token when a user authenticates through an external identity provider. An app can then retrieve from the ID token the list of external groups that the user belongs to. An administrator can use these groups to assign permissions by group rather than individual users.
 
-For more details on how to create resource permission mappings, see <a href="./manage-resources.html#create-resource-perm">Create or Edit Resource Permissions</a>.
+For more details on how to create resource permission mappings, see <a href="./configure-id-providers.html#create-resource-perm">Create or Edit Resource Permissions Mapping</a>.
 
 <p class="note"><strong>Note</strong>: For an app to retrieve a Group Whitelist containing external groups, the app must request the <code>roles</code> scope, and the Group Whitelist must list the external group.</p>
 
@@ -266,7 +266,7 @@ For more details on how to create resource permission mappings, see <a href="./m
 
 ## <a id='create-resource-perm'></a> Create or Edit Resource Permissions Mapping
 
-After a space developer defines resources required by an app, an administrator may map existing groups to those resources.
+After a [space developer defines resources required by an app](./configure-id-providers.html#create-resource-perm), an administrator may map existing groups to those resources.
 
 After resource permissions mappings are configured and a user authenticates,
 the user's group memberships is mapped to scopes in the resulting token.


### PR DESCRIPTION
Three changes:
1. Fixed a link in operator guide that links to new section instead of the removed old section.
2. Added a link from operator guide to part where space developer must first create the resource.
3. Link to uaac group mapping instructions.