### PR TITLE
1.10

### DIFF
--- a/installation.html.md.erb
+++ b/installation.html.md.erb
@@ -41,7 +41,7 @@ staging area.
     deployed as an app from a BOSH errand, and has no associated BOSH
     VMs that require selecting a corresponding network. If you are forced to select
     a network during installation, select the <strong>Deployment</strong> network,
-    also known as the<%= vars.app_runtime_full %> network.</p>
+    also known as the**<%= vars.app_runtime_full %>** network.</p>
 
 1. In the Ops Manager Dashboard, do the following to complete the installation:
 

--- a/installation.html.md.erb
+++ b/installation.html.md.erb
@@ -41,7 +41,7 @@ staging area.
     deployed as an app from a BOSH errand, and has no associated BOSH
     VMs that require selecting a corresponding network. If you are forced to select
     a network during installation, select the <strong>Deployment</strong> network,
-    also known as the**<%= vars.app_runtime_full %>** network.</p>
+    also known as the PAS network.</p>
 
 1. In the Ops Manager Dashboard, do the following to complete the installation:
 


### PR DESCRIPTION
**Issue:** The SSO tile installation was missing the name of the network which it had to be associated with.
Noticed that the 1.10 branch onwards, we have used vars which were not resolving in this particular case. I updated the network to a static "PAS" value. But would be better to update to the correct variable reference to pick up from the common template vars. 