### PR TITLE
Add release notes for 1.10.3

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -12,6 +12,24 @@ These are release notes for the [<%= vars.product_full %>](https://network.pivot
 <%= partial vars.path_to_partials + '/upgrade-planner' %>
 
 
+## <a id="1-10-3"></a> v1.10.3
+
+**Release Date: April 24, 2020**
+
+### <a id="1103-resolved-issues"></a> Resolved Issues
+
+This release has the following fix:
+
+* Space Developers view and select permissions from other spaces in the <%= vars.developer_dash %>
+on the **Register App** page.
+
+### <a id="1103-known-issues"></a> Known Issues
+
+This release has the following issue:
+
+<%= partial vars.path_to_partials + "/identity/known-issue-okta-oidc" %>
+<%= partial vars.path_to_partials + "/identity/logout-ki" %>
+
 ## <a id="1-10-2"></a> v1.10.2
 
 **Release Date: April 13, 2020**


### PR DESCRIPTION
This PR adds release notes for a bug where a space developer did not have the ability to view and select permissions from a different space.

Signed-off-by: Margo Crawford <margaretc@vmware.com>