### PR TITLE
Added instructions for enabling the Internal User Store and user management from UAAC

### DIFF
--- a/configure-internal-us.html.md.erb
+++ b/configure-internal-us.html.md.erb
@@ -88,6 +88,10 @@ To obtain an access token for your admin client:
 
 ## <a id='config-int-store'></a> Configure the Internal User Store
 
+By default, when creating a new plan in v1.13, the internal user store is not enabled.
+UAA will not present the internal user store as an option for users attempting to log in to the zone.
+For plans that were created using an earlier version, the internal user store will retain its previous settings.
+
 To configure the internal user store through the UAAC:
 
 1. If you have not already done so, complete the [Obtain an Access Token](#obtain-token)
@@ -105,6 +109,9 @@ procedure above.
 	<%= vars.app_runtime_abbr %> tile.
 
 1. From the output, capture the JSON and record the `id` for the identity provider named `uaa`.
+
+1. To enable the internal user store, set `active` to `true` within the captured JSON.
+Additionally, to enable user management (adding, updating and deleting internal users), set `config.disableInternalUserManagement` to `false`.
 
 1. Configure to your needs the password policy, email domains, and other settings within the
 captured JSON.


### PR DESCRIPTION
Also explains that the internal user store is disabled by default in 1.13+.

Signed-off-by: Tyler Schultz <tschultz@vmware.com>

Should this be merged to any other branches?

This applies to 1.13+
