### PR TITLE
Remove redundant and incorrect user management instructions.

### DIFF
--- a/configure-internal-us.html.md.erb
+++ b/configure-internal-us.html.md.erb
@@ -155,44 +155,8 @@ captured JSON.
 
 ## <a id='add-to-int'></a> Add Internal Users
 
-You can create new internal user accounts through the UAAC.
-You can also use the **Internal Users** admin pane to send invitations to users to enable them to
-add themselves to the internal user store.
-However, you cannot use the admin pane to add users directly.
-For information about the admin pane,
-see [Manage Users in an Internal User Store](./manage-users.html#internal).
-
-To create new internal user accounts through the UAAC:
-
-1. If you have not already done so, complete the [Obtain an Access Token](#obtain-token)
-procedure above.
-
-1. Add a new user by running:
-
-	```
-	uaac user add --emails USER-EMAIL
-	```
-	Where `USER-EMAIL` is the email address for the user you are creating.
-
-1. When prompted for `User name` and `Password`, enter a username and password for the new user.
-
-1. (Optional) Create a user group and add the user to the group:
-
-  1. Create the user group by running:
-
-		```
-		uaac group add GROUP-NAME
-		```
-		Where `GROUP-NAME` is the name of the group you are creating.
-
-  1. Add a member to your new group by running:
-
-		```
- 		uaac member add GROUP-NAME USER-NAME
-		```
-		Where:
-		* `GROUP-NAME` is the name of your new group
-		* `USER-NAME` is the member you are adding to your new group
+You can create and manage internal user accounts through UAAC.
+See [Manage Users With The UAA CLI](./manage-users.html#uaac).
 
 
 ## <a id='test-id-config'></a> Test Identity Provider Configurations

--- a/manage-users.html.md.erb
+++ b/manage-users.html.md.erb
@@ -48,7 +48,7 @@ be configured by an admin for the service plan.
 
 <p class="note"><strong>Note</strong>:
   Clients and Groups for <%= vars.product_short %> should be created directly using
-  the <%= vars.operator_dash %> or through app manifest bootstrapping.
+  the <%= vars.developer_dash %> or through app manifest bootstrapping.
   Do not create these through UAAC, as additional metadata is required for their
   usage by <%= vars.product_short %>.
 </p>


### PR DESCRIPTION
Instructions to add groups with UAAC would bypass App SSO metadata.
Links to valid instructions on managing users on the Manage Users page.

Also edited the Manage Users page to instruct operators to use the
developer dashboard to create groups instead of the operator dashboard.

Signed-off-by: Tyler Schultz <tschultz@vmware.com>

Should this be merged to any other branches?

This should be merged back to all branches.
