### PR TITLE
Update to 1.14.3 release notes

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -21,42 +21,8 @@ These are release notes for the
 
 Dependency upgrades in this release:
 
-<table class="nice"> <th>Dependency</th> <th>From Version</th>  <th>To Version</th>  <tr>
-    <td>spring-boot-starter-parent</td>
-    <td>2.3.4.RELEASE</td>
-    <td>2.4.8</td>
-  </tr>
-  <tr>
-    <td>log4j-to-slf4j</td>
-    <td>2.13.3</td>
-    <td>2.14.1</td>
-  </tr>
-  <tr>
-    <td>log4j-api</td>
-    <td>2.13.3</td>
-    <td>2.14.1</td>
-  </tr>
-  <tr>
-    <td>lombok</td>
-    <td>1.18.16</td>
-    <td>1.18.20</td>
-  </tr>
-  <tr>
-    <td>guava</td>
-    <td>29.0-jre</td>
-    <td>30.1.1-jre</td>
-  </tr>
-  <tr>
-    <td>org.springframework.cloud.spring-cloud-dependencies</td>
-    <td>Hoxton.SR8</td>
-    <td>Hoxton.SR12</td>
-  </tr>
-  <tr>
-    <td>org.jetbrains.annotations</td>
-    <td>20.1.0</td>
-    <td>21.0.1</td>
-  </tr>
-</table>
+* Spring Boot
+* Apache Tomcat
 
 
 ### Known Issues


### PR DESCRIPTION
Replacing the lower level dependencies with higher level dependencies for security reasons.
