### PR TITLE
Single Sign On for VMware Tanzu 1.14.15

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -13,6 +13,66 @@ This topic describes the changes in this minor release of
 <%= partial vars.path_to_partials + '/services/services-lts-notice', :locals => {
   :eogs_date => "April 2022", :product_version => "1.14"} %>
 
+## <a id="1-14-15"></a> v1.14.15 (and v1.15.2 for Stemcell: Ubuntu Jammy)
+
+**Release date: January 17, 2024**
+
+### Maintenance changes
+
+Support changes:
+
+* None
+
+Dependency upgrades in this release:
+
+* accessors-smart-2.5.0.jar
+* annotations-24.1.0.jar
+* checker-qual-3.37.0.jar
+* commons-io-2.15.1.jar
+* commons-logging-1.3.0.jar
+* commons-validator-1.8.0.jar
+* error_prone_annotations-2.21.1.jar
+* guava-32.1.3-jre.jar
+* jackson-annotations-2.16.1.jar
+* jackson-core-2.16.1.jar
+* jackson-databind-2.16.1.jar
+* jackson-dataformat-xml-2.16.1.jar
+* jackson-datatype-jdk8-2.16.1.jar
+* jackson-datatype-jsr310-2.16.1.jar
+* jackson-module-kotlin-2.16.1.jar
+* jackson-module-parameter-names-2.16.1.jar
+* jakarta.activation-1.2.2.jar
+* jakarta.activation-api-1.2.2.jar
+* jakarta.xml.bind-api-2.3.3.jar
+* jaxb-runtime-2.3.9.jar
+* json-path-2.8.0.jar
+* json-smart-2.5.0.jar
+* log4j-api-2.17.2.jar
+* log4j-to-slf4j-2.17.2.jar
+* logback-classic-1.2.13.jar
+* logback-core-1.2.13.jar
+* lombok-1.18.30.jar
+* micrometer-core-1.9.17.jar
+* prettytime-5.0.7.Final.jar
+* snakeyaml-2.2.jar
+* spring-aop-5.3.31.jar
+* spring-beans-5.3.31.jar
+* spring-boot-2.7.18.jar
+* spring-boot-actuator-2.7.18.jar
+* spring-boot-autoconfigure-2.7.18.jar
+* spring-boot-autoconfigure-2.7.18.jar
+* spring-boot-jarmode-layertools-2.7.18.jar
+* spring-context-5.3.31.jar
+* spring-core-5.3.31.jar
+* spring-expression-5.3.31.jar
+* spring-jcl-5.3.31.jar
+* spring-web-5.3.31.jar
+* spring-webmvc-5.3.31.jar
+* tomcat-embed-core-9.0.83.jar
+* tomcat-embed-el-9.0.83.jar
+* tomcat-embed-websocket-9.0.83.jar
+
+
 ## <a id="1-14-14"></a> v1.14.14 (and v1.15.1 for Stemcell: Ubuntu Jammy)
 
 **Release date: November 06, 2023**


### PR DESCRIPTION
Dependency update for 1.14.15 and 1.15.2

We do not use a separate documentation branch for 1.15.x as the only difference between 1.14 and 1.15 is the stemcell it runs on (Ubuntu Xenial/1.14 Ubuntu Jammy/1.15)

Small patch release for dependency upgrades to address numerous CVE. Both releases were published on Tanzu Network on January 17, 2024. 

Docs follows a bit behind.
